### PR TITLE
traide.jbobau.org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy to traide.jbobau.org via Cloudflare
+
+on:
+  push:
+    branches: [traide-jbobau-org]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Deploy to trade.jbobau.org
+        uses: cloudflare/wrangler-action@v3
+        with:
+          # Secrets from cloudflare.
+          apiToken: ${{ secrets.JBOBAU_API_TOKEN }}
+          accountId: ${{ secrets.JBOBAU_ACCOUNT_ID }}
+          command: pages deploy . --project-name=traide-jbobau-org --branch=traide-jbobau-org

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           submodules: true
 
-      - name: Deploy to trade.jbobau.org
+      - name: Deploy to traide.jbobau.org
         uses: cloudflare/wrangler-action@v3
         with:
           # Secrets from cloudflare.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,6 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           # Secrets from cloudflare.
-          apiToken: ${{ secrets.JBOBAU_API_TOKEN }}
-          accountId: ${{ secrets.JBOBAU_ACCOUNT_ID }}
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy . --project-name=traide-jbobau-org --branch=traide-jbobau-org

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-paclatkerlo.com
+traide.jbobau.org

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # traide-sisku
 
-la lidysisku, except EVIL! [Try it.](https://paclatkerlo.com)
+la lidysisku, except EVIL! [Try it.](https://traide.jbobau.com)
 Also try [la lidysisku](https://sisku.org)

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="author" content="la lalxu" />
     <meta property="og:title" content="la traide sisku" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://paclatkerlo.com/" />
+    <meta property="og:url" content="https://traide.jbobau.com/" />
     <meta
       property="og:description"
       content="lidysisku, except evil"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "traide-jbobau-org"
+pages_build_output_dir = "."
+compatibility_date = "2026-06-09"


### PR DESCRIPTION
Adds cloudflare deploy scripts for Traide Sisku.  Also updates paths for deploying on traide.sisku.org